### PR TITLE
Source FPP's common scripts

### DIFF
--- a/fpp_install.sh
+++ b/fpp_install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source /opt/fpp/scripts/common
 pushd $(dirname $(which $0))
 target_PWD=$(readlink -f .)
 /opt/fpp/scripts/update_plugin ${target_PWD##*/}


### PR DESCRIPTION
Currently the install script will throw an error:
`/home/fpp/media/plugins/FPP-Plugin-Projector-Control/fpp_install.sh: line 10: setSetting: command not found` when setting the restart flag.

Sourcing the `common` scripts will fix that and properly set the flag.